### PR TITLE
Adds destination name to route request

### DIFF
--- a/src/main/java/com/mapzen/valhalla/JSON.java
+++ b/src/main/java/com/mapzen/valhalla/JSON.java
@@ -12,6 +12,18 @@ public class JSON {
     public static class Location {
         public String lat;
         public String lon;
+        public String name;
+
+        public Location(String lat, String lon) {
+            this.lat = lat;
+            this.lon = lon;
+        }
+
+        public Location(String lat, String lon, String name) {
+            this.lat = lat;
+            this.lon = lon;
+            this.name = name;
+        }
     }
 
     public static class DirectionOptions {

--- a/src/main/java/com/mapzen/valhalla/Router.kt
+++ b/src/main/java/com/mapzen/valhalla/Router.kt
@@ -25,6 +25,7 @@ public interface Router {
     public fun setDriving(): Router
     public fun setBiking(): Router
     public fun setLocation(point: DoubleArray): Router
+    public fun setLocation(point: DoubleArray, name: String): Router
     public fun setDistanceUnits(units: DistanceUnits): Router
     public fun clearLocations(): Router
     public fun setEndpoint(url: String): Router

--- a/src/main/java/com/mapzen/valhalla/ValhallaRouter.kt
+++ b/src/main/java/com/mapzen/valhalla/ValhallaRouter.kt
@@ -16,7 +16,7 @@ public open class ValhallaRouter : Router, Runnable {
     private var API_KEY = "";
     private var endpoint: String = DEFAULT_URL
     private var type = Router.Type.DRIVING
-    private val locations = ArrayList<DoubleArray>()
+    private val locations = ArrayList<JSON.Location>()
     private var callback: RouteCallback? = null
     private var units: Router.DistanceUnits = Router.DistanceUnits.KILOMETERS
 
@@ -41,7 +41,12 @@ public open class ValhallaRouter : Router, Runnable {
     }
 
     override fun setLocation(point: DoubleArray): Router {
-        this.locations.add(point)
+        this.locations.add(JSON.Location(point[0].toString(), point[1].toString()));
+        return this
+    }
+
+    override fun setLocation(point: DoubleArray, name: String): Router {
+        this.locations.add(JSON.Location(point[0].toString(), point[1].toString(), name));
         return this
     }
 
@@ -116,12 +121,8 @@ public open class ValhallaRouter : Router, Runnable {
             throw  MalformedURLException();
         }
         var json: JSON = JSON();
-        json.locations[0] = JSON.Location()
-        json.locations[1] = JSON.Location()
-        json.locations[0].lat = locations.get(0)[0].toString()
-        json.locations[0].lon = locations.get(0)[1].toString()
-        json.locations[1].lat = locations.get(1)[0].toString()
-        json.locations[1].lon = locations.get(1)[1].toString()
+        json.locations[0] = locations.get(0)
+        json.locations[1] = locations.get(1)
         json.costing = this.type.toString()
         json.directionsOptions.units = this.units.toString()
         return json

--- a/src/test/java/com/mapzen/valhalla/RouterTest.java
+++ b/src/test/java/com/mapzen/valhalla/RouterTest.java
@@ -238,6 +238,20 @@ public class RouterTest {
                 .contains("\"directions_options\":{\"units\":\"kilometers\"}");
     }
 
+    @Test
+    public void setLocation_shouldAppendName() throws Exception {
+        double[] loc = new double[] {1.0, 2.0};
+        router = new ValhallaRouter().setLocation(loc).setLocation(loc, "Acme");
+        assertThat(new Gson().toJson(router.getJSONRequest()))
+                .contains("{\"lat\":\"1.0\",\"lon\":\"2.0\",\"name\":\"Acme\"}");
+    }
+
+    @Test
+    public void setLocation_shouldNotIncludeNameParamIfNotSet() throws Exception {
+        assertThat(new Gson().toJson(router.getJSONRequest()))
+                .doesNotContain("\"name\"");
+    }
+
     private void startServerAndEnqueue(MockResponse response) throws Exception {
         server.enqueue(response);
     }


### PR DESCRIPTION
Destination name is used in final instruction.

For example if you pass the destination name "Acme" rather than the generic "You have arrived at your destination" instead the final instruction will be "You have arrived at Acme".