### PR TITLE
Improved route start

### DIFF
--- a/src/main/java/com/mapzen/helpers/RouteEngine.java
+++ b/src/main/java/com/mapzen/helpers/RouteEngine.java
@@ -19,7 +19,6 @@ public class RouteEngine {
     public static final int DESTINATION_RADIUS = 30;
 
     public enum RouteState {
-        START,
         PRE_INSTRUCTION,
         INSTRUCTION,
         COMPLETE,
@@ -47,11 +46,6 @@ public class RouteEngine {
 
         this.location = location;
         snapLocation();
-
-        if (routeState == RouteState.START) {
-            listener.onApproachInstruction(0);
-            routeState = RouteState.PRE_INSTRUCTION;
-        }
 
         if (routeState == RouteState.COMPLETE) {
             listener.onUpdateDistance(0, 0);
@@ -110,11 +104,9 @@ public class RouteEngine {
             listener.onRouteComplete();
         }
 
-        if (routeState != RouteState.START) {
-            if (route.isLost()) {
-                routeState = RouteState.LOST;
-                listener.onRecalculate(location);
-            }
+        if (route.isLost()) {
+            routeState = RouteState.LOST;
+            listener.onRecalculate(location);
         }
     }
 
@@ -134,12 +126,18 @@ public class RouteEngine {
     }
 
     public void setRoute(Route route) {
+        if (listener == null) {
+            throw new IllegalStateException("Route listener is null");
+        }
+
         this.route = route;
-        routeState = RouteState.START;
         instructions = route.getRouteInstructions();
         if (instructions != null) {
             currentInstruction = instructions.get(0);
         }
+
+        listener.onRouteStart();
+        routeState = RouteState.PRE_INSTRUCTION;
     }
 
     public Route getRoute() {

--- a/src/main/java/com/mapzen/helpers/RouteListener.java
+++ b/src/main/java/com/mapzen/helpers/RouteListener.java
@@ -7,6 +7,11 @@ import android.location.Location;
  */
 public interface RouteListener {
     /**
+     * Invoked at the beginning of a new route.
+     */
+    public void onRouteStart();
+
+    /**
      * Invoked when the given location is off course and the route needs to be recalculated.
      */
     public void onRecalculate(Location location);


### PR DESCRIPTION
The `RouteEngine` no longer waits for the first location update to signal to the listener the route has begun. This is now integrated into the process of setting a new route. This will allow for special handling of route start via the `RouteListener` in client applications.

* Adds `onRouteStart()` callback method to `RouteListener` interface.
* `onRouteStart()` is explicitly called when a new route is set.
* `setRoute()` throws an exception if route is set but no listener is attached.
* Removes `START` state from `RouteState` enum since this phase is now hardcoded and no longer linked to location updates.
* Removes conditional that prevents rerouting in `START` state.