### PR TITLE
Upgrade Kotlin version from Beta to RC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.0.0'
+  ext.kotlin_version = '1.0.1'
 
   repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.0.0-beta-1103'
+  ext.kotlin_version = '1.0.0'
 
   repositories {
     mavenCentral()

--- a/src/main/java/com/mapzen/valhalla/Route.kt
+++ b/src/main/java/com/mapzen/valhalla/Route.kt
@@ -489,7 +489,7 @@ public open class Route {
     }
 
     public open fun getNextInstructionIndex(): Int? {
-        return instructions!!.indexOfRaw(getNextInstruction())
+        return instructions?.indexOf(getNextInstruction())
     }
 
     public open fun getCurrentInstruction(): Instruction {

--- a/src/test/java/com/mapzen/valhalla/RouteTest.java
+++ b/src/test/java/com/mapzen/valhalla/RouteTest.java
@@ -49,7 +49,7 @@ public class RouteTest {
     public void shouldConvertTotalDistanceInMilesToMeters() throws Exception {
         route = getRoute("valhalla_miles");
         assertThat(route.getTotalDistance())
-                .isEqualTo((int) Math.round(0.712 * Instruction.MI_TO_METERS));
+                .isEqualTo((int) Math.round(0.712 * Instruction.Companion.getMI_TO_METERS()));
     }
 
     @Test


### PR DESCRIPTION
Due to an apparent change in the format of .class files between the Beta and RC versions of Kotlin, on-the-road will need to be re-compiled and released with a new version in order to be used as a dependency in any other projects using an RC version of Kotlin. 