### PR TITLE
Increase alert radius to 100 meters

### DIFF
--- a/src/main/java/com/mapzen/helpers/RouteEngine.java
+++ b/src/main/java/com/mapzen/helpers/RouteEngine.java
@@ -15,7 +15,7 @@ import static com.mapzen.helpers.DistanceFormatter.METERS_IN_ONE_MILE;
  */
 public class RouteEngine {
     public static final int APPROACH_RADIUS = 50;
-    public static final int ALERT_RADIUS = 50;
+    public static final int ALERT_RADIUS = 100;
     public static final int DESTINATION_RADIUS = 30;
 
     public enum RouteState {


### PR DESCRIPTION
Based on testing in Eraser Map verbal pre-maneuver instructions should be called out with more advance warning. Let's try doubling the distance from 50 to 100 meters and see how that feels.

Fixes https://github.com/mapzen/eraser-map/issues/366