### PR TITLE
Revert "Send DNT header to disable server-side logging"

### DIFF
--- a/src/main/java/com/mapzen/valhalla/Router.kt
+++ b/src/main/java/com/mapzen/valhalla/Router.kt
@@ -41,6 +41,4 @@ public interface Router {
     public fun fetch()
     public fun getJSONRequest(): JSON
     public fun setLogLevel(logLevel: RestAdapter.LogLevel): Router
-    public fun setDntEnabled(enabled: Boolean): Router
-    public fun isDntEnabled(): Boolean
 }

--- a/src/main/java/com/mapzen/valhalla/ValhallaRouter.kt
+++ b/src/main/java/com/mapzen/valhalla/ValhallaRouter.kt
@@ -3,7 +3,6 @@ package com.mapzen.valhalla
 import com.google.gson.Gson
 import com.mapzen.helpers.CharStreams
 import com.mapzen.helpers.ResultConverter
-import retrofit.RequestInterceptor
 import retrofit.RestAdapter
 import retrofit.RetrofitError
 import retrofit.client.Response
@@ -21,12 +20,6 @@ public open class ValhallaRouter : Router, Runnable {
     private var callback: RouteCallback? = null
     private var units: Router.DistanceUnits = Router.DistanceUnits.KILOMETERS
     private var logLevel: RestAdapter.LogLevel = RestAdapter.LogLevel.NONE
-    protected var dntEnabled: Boolean = true
-
-    companion object {
-        private val HEADER_DNT = "DNT"
-        private val VALUE_DNT = "1"
-    }
 
     override fun setApiKey(key: String): Router {
         API_KEY = key
@@ -110,11 +103,6 @@ public open class ValhallaRouter : Router, Runnable {
                 .setConverter(ResultConverter())
                 .setEndpoint(DEFAULT_URL)
                 .setLogLevel(logLevel)
-                .setRequestInterceptor { request ->
-                    if (this.dntEnabled) {
-                        request?.addHeader(HEADER_DNT, VALUE_DNT)
-                    }
-                }
                 .build()
 
         var routingService = RestAdapterFactory(restAdapter).getRoutingService();
@@ -147,14 +135,5 @@ public open class ValhallaRouter : Router, Runnable {
     override fun setLogLevel(logLevel: RestAdapter.LogLevel): Router {
         this.logLevel = logLevel
         return this
-    }
-
-    override fun setDntEnabled(enabled: Boolean): Router {
-        this.dntEnabled = enabled
-        return this
-    }
-
-    override fun isDntEnabled(): Boolean {
-        return this.dntEnabled
     }
 }

--- a/src/test/java/com/mapzen/valhalla/RouterTest.java
+++ b/src/test/java/com/mapzen/valhalla/RouterTest.java
@@ -5,7 +5,6 @@ import com.google.common.io.Files;
 import com.google.gson.Gson;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
 import org.json.JSONException;
 import org.junit.After;
@@ -80,11 +79,6 @@ public class RouterTest {
     }
 
     @Test
-    public void shouldSendDntByDefault() {
-        assertThat(router.isDntEnabled()).isTrue();
-    }
-
-    @Test
     public void shouldClearLocations() throws Exception {
         double[] loc1 = { 1.0, 2.0 };
         double[] loc2 = { 3.0, 4.0 };
@@ -136,8 +130,8 @@ public class RouterTest {
                 RouteCallback callback = Mockito.mock(RouteCallback.class);
                 Router router = new ValhallaRouter()
                         .setEndpoint(endpoint)
-                        .setLocation(new double[] { 40.659241, -73.983776 })
-                        .setLocation(new double[] { 40.671773, -73.981115 });
+                        .setLocation(new double[]{40.659241, -73.983776})
+                        .setLocation(new double[]{40.671773, -73.981115});
                 router.setCallback(callback);
                 router.fetch();
                 Mockito.verify(callback).success(route.capture());
@@ -199,8 +193,8 @@ public class RouterTest {
                 String endpoint = server.getUrl("").toString();
                 Router router = new ValhallaRouter()
                         .setEndpoint(endpoint)
-                        .setLocation(new double[] { 40.659241, -73.983776 })
-                        .setLocation(new double[] { 40.671773, -73.981115 });
+                        .setLocation(new double[]{40.659241, -73.983776})
+                        .setLocation(new double[]{40.671773, -73.981115});
                 router.setCallback(callback);
                 router.fetch();
                 Mockito.verify(callback).failure(statusCode.capture());
@@ -273,61 +267,10 @@ public class RouterTest {
     @Test
     public void setLocation_shouldIncludeHeading() throws Exception {
         double[] loc = new double[] {1.0, 2.0};
-        router = new ValhallaRouter().setLocation(loc, 180).setLocation(loc);
+        router = new ValhallaRouter().setLocation(loc,180).setLocation(loc);
         assertThat(new Gson().toJson(router.getJSONRequest()))
                 .contains("{\"lat\":\"1.0\",\"lon\":\"2.0\",\"heading\":\"180\"}");
     }
-
-    @Test
-    public void setDntEnabled_shouldSendHeader() throws Exception {
-        startServerAndEnqueue(new MockResponse());
-        ExecutorService executorService = Executors.newSingleThreadExecutor();
-        executorService.execute(new Runnable() {
-            @Override
-            public void run() {
-                String endpoint = server.getUrl("").toString();
-                Router router = new ValhallaRouter()
-                        .setEndpoint(endpoint)
-                        .setLocation(new double[] { 40.659241, -73.983776 })
-                        .setLocation(new double[] { 40.671773, -73.981115 });
-                router.fetch();
-                RecordedRequest request = null;
-                try {
-                    request = server.takeRequest();
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-                assertThat(request.getHeader("DNT")).isNotNull();
-                assertThat(request.getHeader("DNT")).isEqualTo("1");
-            }
-        });
-    }
-
-    @Test
-    public void setDntDisabled_shouldNotSendHeader() throws Exception {
-        startServerAndEnqueue(new MockResponse());
-        ExecutorService executorService = Executors.newSingleThreadExecutor();
-        executorService.execute(new Runnable() {
-            @Override
-            public void run() {
-                String endpoint = server.getUrl("").toString();
-                Router router = new ValhallaRouter()
-                        .setEndpoint(endpoint)
-                        .setLocation(new double[] { 40.659241, -73.983776 })
-                        .setLocation(new double[] { 40.671773, -73.981115 });
-                router.setDntEnabled(false);
-                router.fetch();
-                RecordedRequest request = null;
-                try {
-                    request = server.takeRequest();
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-                assertThat(request.getHeader("DNT")).isNull();
-            }
-        });
-    }
-
 
     private void startServerAndEnqueue(MockResponse response) throws Exception {
         server.enqueue(response);


### PR DESCRIPTION
Reverts mapzen/on-the-road#58

This functionality should be included in EraserMap, not at the SDK level. 