### PR TITLE
Fix set endpoint

### DIFF
--- a/src/main/java/com/mapzen/valhalla/ValhallaRouter.kt
+++ b/src/main/java/com/mapzen/valhalla/ValhallaRouter.kt
@@ -25,7 +25,7 @@ public open class ValhallaRouter : Router, Runnable {
     private var callback: RouteCallback? = null
     private var units: Router.DistanceUnits = Router.DistanceUnits.KILOMETERS
     private var logLevel: RestAdapter.LogLevel = RestAdapter.LogLevel.NONE
-    protected var dntEnabled: Boolean = true
+    protected var dntEnabled: Boolean = false
 
     override fun setApiKey(key: String): Router {
         API_KEY = key

--- a/src/main/java/com/mapzen/valhalla/ValhallaRouter.kt
+++ b/src/main/java/com/mapzen/valhalla/ValhallaRouter.kt
@@ -3,7 +3,6 @@ package com.mapzen.valhalla
 import com.google.gson.Gson
 import com.mapzen.helpers.CharStreams
 import com.mapzen.helpers.ResultConverter
-import retrofit.RequestInterceptor
 import retrofit.RestAdapter
 import retrofit.RetrofitError
 import retrofit.client.Response
@@ -13,7 +12,12 @@ import java.net.MalformedURLException
 import java.util.ArrayList
 
 public open class ValhallaRouter : Router, Runnable {
-    private val DEFAULT_URL = "https://valhalla.mapzen.com/"
+    companion object {
+        public const val DEFAULT_URL = "https://valhalla.mapzen.com/"
+        private const val HEADER_DNT = "DNT"
+        private const val VALUE_DNT = "1"
+    }
+
     private var API_KEY = "";
     private var endpoint: String = DEFAULT_URL
     private var type = Router.Type.DRIVING
@@ -22,11 +26,6 @@ public open class ValhallaRouter : Router, Runnable {
     private var units: Router.DistanceUnits = Router.DistanceUnits.KILOMETERS
     private var logLevel: RestAdapter.LogLevel = RestAdapter.LogLevel.NONE
     protected var dntEnabled: Boolean = true
-
-    companion object {
-        private val HEADER_DNT = "DNT"
-        private val VALUE_DNT = "1"
-    }
 
     override fun setApiKey(key: String): Router {
         API_KEY = key
@@ -108,7 +107,7 @@ public open class ValhallaRouter : Router, Runnable {
     override fun run() {
         var restAdapter: RestAdapter = RestAdapter.Builder()
                 .setConverter(ResultConverter())
-                .setEndpoint(DEFAULT_URL)
+                .setEndpoint(endpoint)
                 .setLogLevel(logLevel)
                 .setRequestInterceptor { request ->
                     if (this.dntEnabled) {

--- a/src/test/java/com/mapzen/valhalla/RouterTest.java
+++ b/src/test/java/com/mapzen/valhalla/RouterTest.java
@@ -80,8 +80,8 @@ public class RouterTest {
     }
 
     @Test
-    public void shouldSendDntByDefault() {
-        assertThat(router.isDntEnabled()).isTrue();
+    public void shouldNotSendDntByDefault() {
+        assertThat(router.isDntEnabled()).isFalse();
     }
 
     @Test
@@ -281,51 +281,30 @@ public class RouterTest {
     @Test
     public void setDntEnabled_shouldSendHeader() throws Exception {
         startServerAndEnqueue(new MockResponse());
-        ExecutorService executorService = Executors.newSingleThreadExecutor();
-        executorService.execute(new Runnable() {
-            @Override
-            public void run() {
-                String endpoint = server.getUrl("").toString();
-                Router router = new ValhallaRouter()
-                        .setEndpoint(endpoint)
-                        .setLocation(new double[] { 40.659241, -73.983776 })
-                        .setLocation(new double[] { 40.671773, -73.981115 });
-                router.fetch();
-                RecordedRequest request = null;
-                try {
-                    request = server.takeRequest();
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-                assertThat(request.getHeader("DNT")).isNotNull();
-                assertThat(request.getHeader("DNT")).isEqualTo("1");
-            }
-        });
+        String endpoint = server.getUrl("").toString();
+        Router router = new ValhallaRouter()
+                .setEndpoint(endpoint)
+                .setLocation(new double[] { 40.659241, -73.983776 })
+                .setLocation(new double[] { 40.671773, -73.981115 })
+                .setDntEnabled(true);
+        ((ValhallaRouter) router).run();
+        RecordedRequest request = server.takeRequest();
+        assertThat(request.getHeader("DNT")).isNotNull();
+        assertThat(request.getHeader("DNT")).isEqualTo("1");
     }
 
     @Test
     public void setDntDisabled_shouldNotSendHeader() throws Exception {
         startServerAndEnqueue(new MockResponse());
-        ExecutorService executorService = Executors.newSingleThreadExecutor();
-        executorService.execute(new Runnable() {
-            @Override
-            public void run() {
-                String endpoint = server.getUrl("").toString();
-                Router router = new ValhallaRouter()
-                        .setEndpoint(endpoint)
-                        .setLocation(new double[] { 40.659241, -73.983776 })
-                        .setLocation(new double[] { 40.671773, -73.981115 });
-                router.setDntEnabled(false);
-                router.fetch();
-                RecordedRequest request = null;
-                try {
-                    request = server.takeRequest();
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-                assertThat(request.getHeader("DNT")).isNull();
-            }
-        });
+        String endpoint = server.getUrl("").toString();
+        Router router = new ValhallaRouter()
+                .setEndpoint(endpoint)
+                .setLocation(new double[] { 40.659241, -73.983776 })
+                .setLocation(new double[] { 40.671773, -73.981115 })
+                .setDntEnabled(false);
+        ((ValhallaRouter) router).run();
+        RecordedRequest request = server.takeRequest();
+        assertThat(request.getHeader("DNT")).isNull();
     }
 
     @Test

--- a/src/test/java/com/mapzen/valhalla/RouterTest.java
+++ b/src/test/java/com/mapzen/valhalla/RouterTest.java
@@ -328,6 +328,18 @@ public class RouterTest {
         });
     }
 
+    @Test
+    public void setEndpoint_shouldUpdateBaseRequestUrl() throws Exception {
+        startServerAndEnqueue(new MockResponse());
+        String endpoint = server.getUrl("/test").toString();
+        Router router = new ValhallaRouter()
+                .setEndpoint(endpoint)
+                .setLocation(new double[] { 40.659241, -73.983776 })
+                .setLocation(new double[] { 40.671773, -73.981115 });
+        ((ValhallaRouter) router).run();
+        RecordedRequest request = server.takeRequest();
+        assertThat(request.getPath()).contains("/test");
+    }
 
     private void startServerAndEnqueue(MockResponse response) throws Exception {
         server.enqueue(response);


### PR DESCRIPTION
* Updates `ValhallaRouter` so it uses the server base URL set by the client (if one is provided).
* Updates DNT header default value to `false`.
* Also fixes DNT tests to run on single thread so when assert fails then testing framework also reports the failure. By default asserts in background threads are not reported as test failures.