### PR TITLE
Add HttpHandler for Router

### DIFF
--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -83,7 +83,9 @@ afterEvaluate { project ->
   }
 
   task androidJavadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
+    if (!project.plugins.hasPlugin('kotlin-android')) {
+      source = android.sourceSets.main.java.srcDirs
+    }
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
     exclude '**/*.kt'
 

--- a/src/main/java/com/mapzen/helpers/RouteEngine.java
+++ b/src/main/java/com/mapzen/helpers/RouteEngine.java
@@ -139,7 +139,7 @@ public class RouteEngine {
 
     /**
      * Sets the route for engine, gets route instructions, calls listener method to notify that the
-     * route has started, and updates route state to {@link RouteState.PRE_INSTRUCTION}
+     * route has started, and updates route state to {@code RouteState.PRE_INSTRUCTION}
      *
      * Listener must be set before calling this or IllegalStateException is thrown
      * @param route

--- a/src/main/java/com/mapzen/valhalla/HttpHandler.java
+++ b/src/main/java/com/mapzen/valhalla/HttpHandler.java
@@ -13,10 +13,9 @@ import retrofit.RestAdapter;
  */
 public class HttpHandler {
 
-  private static final String DEFAULT_URL = "https://valhalla.mapzen.com/";
-  private static final RestAdapter.LogLevel DEFAULT_LOG_LEVEL = RestAdapter.LogLevel.NONE;
+  protected static final String DEFAULT_URL = "https://valhalla.mapzen.com/";
+  protected static final RestAdapter.LogLevel DEFAULT_LOG_LEVEL = RestAdapter.LogLevel.NONE;
 
-  String apiKey;
   String endpoint;
   RestAdapter.LogLevel logLevel;
   RestAdapter adapter;
@@ -24,20 +23,27 @@ public class HttpHandler {
 
   private RequestInterceptor requestInterceptor = new RequestInterceptor() {
     @Override public void intercept(RequestFacade request) {
-      addHeadersForRequest(request);
+      onRequest(request);
     }
   };
 
-  public HttpHandler(String apiKey) {
-    this(apiKey, DEFAULT_URL, DEFAULT_LOG_LEVEL);
+  public HttpHandler() {
+    this(DEFAULT_URL, DEFAULT_LOG_LEVEL);
   }
 
-  public HttpHandler(String apiKey, RestAdapter.LogLevel logLevel) {
-    this(apiKey, DEFAULT_URL, logLevel);
+  public HttpHandler(String endpoint) {
+    this(endpoint, DEFAULT_LOG_LEVEL);
   }
 
-  public HttpHandler(String apiKey, String endpoint, RestAdapter.LogLevel logLevel) {
-    this.apiKey = apiKey;
+  public HttpHandler(RestAdapter.LogLevel logLevel) {
+    this(DEFAULT_URL, logLevel);
+  }
+
+  public HttpHandler(String endpoint, RestAdapter.LogLevel logLevel) {
+    configure(endpoint, logLevel);
+  }
+
+  protected void configure(String endpoint, RestAdapter.LogLevel logLevel) {
     this.endpoint = endpoint;
     this.logLevel = logLevel;
     this.adapter = new RestAdapter.Builder()
@@ -50,14 +56,14 @@ public class HttpHandler {
   }
 
   public void requestRoute(String routeJson, Callback callback) {
-    service.getRoute(routeJson, apiKey, callback);
+    service.getRoute(routeJson, callback);
   }
 
   /**
    * Subclasses can overwrite to add custom headers to each request
    * @param requestFacade
    */
-  protected void addHeadersForRequest(RequestInterceptor.RequestFacade requestFacade) {
+  protected void onRequest(RequestInterceptor.RequestFacade requestFacade) {
 
   }
 

--- a/src/main/java/com/mapzen/valhalla/HttpHandler.java
+++ b/src/main/java/com/mapzen/valhalla/HttpHandler.java
@@ -9,7 +9,10 @@ import retrofit.RequestInterceptor;
 import retrofit.RestAdapter;
 
 /**
- *
+ *  Handles all things http including setting the route engine's url and request log level. Route
+ *  requests can be made using this object. To customize headers and params that are sent with each
+ *  request, subclass this object and overwrite
+ *  {@link HttpHandler#onRequest(RequestInterceptor.RequestFacade)}
  */
 public class HttpHandler {
 

--- a/src/main/java/com/mapzen/valhalla/HttpHandler.java
+++ b/src/main/java/com/mapzen/valhalla/HttpHandler.java
@@ -1,0 +1,65 @@
+package com.mapzen.valhalla;
+
+import com.mapzen.helpers.ResultConverter;
+import com.mapzen.valhalla.RestAdapterFactory;
+import com.mapzen.valhalla.RoutingService;
+
+import retrofit.Callback;
+import retrofit.RequestInterceptor;
+import retrofit.RestAdapter;
+
+/**
+ *
+ */
+public class HttpHandler {
+
+  private static final String DEFAULT_URL = "https://valhalla.mapzen.com/";
+  private static final RestAdapter.LogLevel DEFAULT_LOG_LEVEL = RestAdapter.LogLevel.NONE;
+
+  String apiKey;
+  String endpoint;
+  RestAdapter.LogLevel logLevel;
+  RestAdapter adapter;
+  RoutingService service;
+
+  private RequestInterceptor requestInterceptor = new RequestInterceptor() {
+    @Override public void intercept(RequestFacade request) {
+      addHeadersForRequest(request);
+    }
+  };
+
+  public HttpHandler(String apiKey) {
+    this(apiKey, DEFAULT_URL, DEFAULT_LOG_LEVEL);
+  }
+
+  public HttpHandler(String apiKey, RestAdapter.LogLevel logLevel) {
+    this(apiKey, DEFAULT_URL, logLevel);
+  }
+
+  public HttpHandler(String apiKey, String endpoint, RestAdapter.LogLevel logLevel) {
+    this.apiKey = apiKey;
+    this.endpoint = endpoint;
+    this.logLevel = logLevel;
+    this.adapter = new RestAdapter.Builder()
+        .setConverter(new ResultConverter())
+        .setEndpoint(endpoint)
+        .setLogLevel(logLevel)
+        .setRequestInterceptor(requestInterceptor)
+        .build();
+    this.service = new RestAdapterFactory(this.adapter).getRoutingService();
+  }
+
+  public void requestRoute(String routeJson, Callback callback) {
+    service.getRoute(routeJson, apiKey, callback);
+  }
+
+  /**
+   * Subclasses can overwrite to add custom headers to each request
+   * @param requestFacade
+   */
+  protected void addHeadersForRequest(RequestInterceptor.RequestFacade requestFacade) {
+
+  }
+
+}
+

--- a/src/main/java/com/mapzen/valhalla/Router.kt
+++ b/src/main/java/com/mapzen/valhalla/Router.kt
@@ -1,7 +1,5 @@
 package com.mapzen.valhalla
 
-import retrofit.RestAdapter
-
 interface Router {
     enum class Type(private val type: String) {
         WALKING("pedestrian"),
@@ -22,7 +20,7 @@ interface Router {
         }
     }
 
-    fun setApiKey(key: String): Router
+    fun setHttpHandler(handler: HttpHandler): Router
     fun setWalking(): Router
     fun setDriving(): Router
     fun setBiking(): Router
@@ -35,12 +33,7 @@ interface Router {
             state: String? = null): Router
     fun setDistanceUnits(units: DistanceUnits): Router
     fun clearLocations(): Router
-    fun setEndpoint(url: String): Router
-    fun getEndpoint(): String
     fun setCallback(callback: RouteCallback): Router
     fun fetch()
     fun getJSONRequest(): JSON
-    fun setLogLevel(logLevel: RestAdapter.LogLevel): Router
-    fun setDntEnabled(enabled: Boolean): Router
-    fun isDntEnabled(): Boolean
 }

--- a/src/main/java/com/mapzen/valhalla/RoutingService.java
+++ b/src/main/java/com/mapzen/valhalla/RoutingService.java
@@ -7,7 +7,5 @@ public interface RoutingService {
     @GET("/route") void getRoute(
             @Query("json")
             String json,
-            @Query("api_key")
-            String apiKey,
             retrofit.Callback<String> callback);
 }

--- a/src/test/java/com/mapzen/TestUtils.java
+++ b/src/test/java/com/mapzen/TestUtils.java
@@ -2,11 +2,28 @@ package com.mapzen;
 
 import com.mapzen.model.ValhallaLocation;
 
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+
+import java.io.File;
+
 public class TestUtils {
-    static public ValhallaLocation getLocation(double lat, double lng) {
+    public static ValhallaLocation getLocation(double lat, double lng) {
         ValhallaLocation loc = new ValhallaLocation();
         loc.setLatitude(lat);
         loc.setLongitude(lng);
         return loc;
+    }
+
+    public static String getFixture(String name) {
+        String basedir = System.getProperty("user.dir");
+        File file = new File(basedir + "/src/test/fixtures/" + name + ".route");
+        String fixture = "";
+        try {
+            fixture = Files.toString(file, Charsets.UTF_8);
+        } catch (Exception e) {
+            fixture = "not found";
+        }
+        return fixture;
     }
 }

--- a/src/test/java/com/mapzen/valhalla/HttpHandlerTest.java
+++ b/src/test/java/com/mapzen/valhalla/HttpHandlerTest.java
@@ -24,12 +24,7 @@ public class HttpHandlerTest {
   HttpHandler httpHandler;
 
   @Before public void setup() throws IOException {
-    httpHandler = new HttpHandler("test", endpoint, RestAdapter.LogLevel.NONE);
-  }
-
-  @Test public void shouldHaveApiKey() {
-    String key = (String) Whitebox.getInternalState(httpHandler, "apiKey");
-    assertThat(key).isEqualTo("test");
+    httpHandler = new HttpHandler(endpoint, RestAdapter.LogLevel.NONE);
   }
 
   @Test public void shouldHaveEndpoint() {
@@ -53,7 +48,7 @@ public class HttpHandlerTest {
       @Override
       public void run() {
         String endpoint = server.getUrl("").toString();
-        TestHttpHandler httpHandler = new TestHttpHandler("key", endpoint, RestAdapter.LogLevel.NONE);
+        TestHttpHandler httpHandler = new TestHttpHandler(endpoint, RestAdapter.LogLevel.NONE);
         Router router = new ValhallaRouter()
             .setHttpHandler(httpHandler)
             .setLocation(new double[] { 40.659241, -73.983776 })
@@ -70,12 +65,12 @@ public class HttpHandlerTest {
 
     public boolean headersAdded = false;
 
-    public TestHttpHandler(String apiKey, String endpoint, RestAdapter.LogLevel logLevel) {
-      super(apiKey, endpoint, logLevel);
+    public TestHttpHandler(String endpoint, RestAdapter.LogLevel logLevel) {
+      super( endpoint, logLevel);
     }
 
     @Override
-    protected void addHeadersForRequest(RequestInterceptor.RequestFacade requestFacade) {
+    protected void onRequest(RequestInterceptor.RequestFacade requestFacade) {
       headersAdded = true;
     }
   }

--- a/src/test/java/com/mapzen/valhalla/HttpHandlerTest.java
+++ b/src/test/java/com/mapzen/valhalla/HttpHandlerTest.java
@@ -9,12 +9,9 @@ import org.mockito.Mockito;
 import org.mockito.internal.util.reflection.Whitebox;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import static com.mapzen.TestUtils.getFixture;
 import static org.fest.assertions.api.Assertions.assertThat;
-import retrofit.Endpoint;
 import retrofit.RequestInterceptor;
 import retrofit.RestAdapter;
 
@@ -43,22 +40,16 @@ public class HttpHandlerTest {
     final MockWebServer server = new MockWebServer();
     server.start();
     server.enqueue(new MockResponse().setBody(getFixture("brooklyn")));
-    ExecutorService executorService = Executors.newSingleThreadExecutor();
-    executorService.execute(new Runnable() {
-      @Override
-      public void run() {
-        String endpoint = server.getUrl("").toString();
-        TestHttpHandler httpHandler = new TestHttpHandler(endpoint, RestAdapter.LogLevel.NONE);
-        Router router = new ValhallaRouter()
-            .setHttpHandler(httpHandler)
-            .setLocation(new double[] { 40.659241, -73.983776 })
-            .setLocation(new double[] { 40.671773, -73.981115 });
-        RouteCallback callback = Mockito.mock(RouteCallback.class);
-        router.setCallback(callback);
-        router.fetch();
-        assertThat(httpHandler.headersAdded).isTrue();
-      }
-    });
+    String endpoint = server.getUrl("").toString();
+    TestHttpHandler httpHandler = new TestHttpHandler(endpoint, RestAdapter.LogLevel.NONE);
+    Router router = new ValhallaRouter()
+        .setHttpHandler(httpHandler)
+        .setLocation(new double[] { 40.659241, -73.983776 })
+        .setLocation(new double[] { 40.671773, -73.981115 });
+    RouteCallback callback = Mockito.mock(RouteCallback.class);
+    router.setCallback(callback);
+    ((ValhallaRouter) router).run();
+    assertThat(httpHandler.headersAdded).isTrue();
   }
 
   private class TestHttpHandler extends HttpHandler {

--- a/src/test/java/com/mapzen/valhalla/HttpHandlerTest.java
+++ b/src/test/java/com/mapzen/valhalla/HttpHandlerTest.java
@@ -1,0 +1,82 @@
+package com.mapzen.valhalla;
+
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.internal.util.reflection.Whitebox;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static com.mapzen.TestUtils.getFixture;
+import static org.fest.assertions.api.Assertions.assertThat;
+import retrofit.Endpoint;
+import retrofit.RequestInterceptor;
+import retrofit.RestAdapter;
+
+public class HttpHandlerTest {
+
+  String endpoint = "https://valhalla.mapzen.com/";
+  HttpHandler httpHandler;
+
+  @Before public void setup() throws IOException {
+    httpHandler = new HttpHandler("test", endpoint, RestAdapter.LogLevel.NONE);
+  }
+
+  @Test public void shouldHaveApiKey() {
+    String key = (String) Whitebox.getInternalState(httpHandler, "apiKey");
+    assertThat(key).isEqualTo("test");
+  }
+
+  @Test public void shouldHaveEndpoint() {
+    final String endpoint =
+        (String) Whitebox.getInternalState(httpHandler, "endpoint");
+    assertThat(endpoint).startsWith("https://valhalla.mapzen.com/");
+  }
+
+  @Test public void shouldHaveLogLevel() {
+    final RestAdapter.LogLevel logLevel =
+        (RestAdapter.LogLevel) Whitebox.getInternalState(httpHandler, "logLevel");
+    assertThat(logLevel).isEqualTo(RestAdapter.LogLevel.NONE);
+  }
+
+  @Test public void shouldAddHeaders() throws IOException {
+    final MockWebServer server = new MockWebServer();
+    server.start();
+    server.enqueue(new MockResponse().setBody(getFixture("brooklyn")));
+    ExecutorService executorService = Executors.newSingleThreadExecutor();
+    executorService.execute(new Runnable() {
+      @Override
+      public void run() {
+        String endpoint = server.getUrl("").toString();
+        TestHttpHandler httpHandler = new TestHttpHandler("key", endpoint, RestAdapter.LogLevel.NONE);
+        Router router = new ValhallaRouter()
+            .setHttpHandler(httpHandler)
+            .setLocation(new double[] { 40.659241, -73.983776 })
+            .setLocation(new double[] { 40.671773, -73.981115 });
+        RouteCallback callback = Mockito.mock(RouteCallback.class);
+        router.setCallback(callback);
+        router.fetch();
+        assertThat(httpHandler.headersAdded).isTrue();
+      }
+    });
+  }
+
+  private class TestHttpHandler extends HttpHandler {
+
+    public boolean headersAdded = false;
+
+    public TestHttpHandler(String apiKey, String endpoint, RestAdapter.LogLevel logLevel) {
+      super(apiKey, endpoint, logLevel);
+    }
+
+    @Override
+    protected void addHeadersForRequest(RequestInterceptor.RequestFacade requestFacade) {
+      headersAdded = true;
+    }
+  }
+}

--- a/src/test/java/com/mapzen/valhalla/RouterTest.java
+++ b/src/test/java/com/mapzen/valhalla/RouterTest.java
@@ -39,7 +39,7 @@ public class RouterTest {
         double[] loc = new double[] {1.0, 2.0};
         router = new ValhallaRouter().setLocation(loc).setLocation(loc);
         String endpoint = server.getUrl("").toString();
-        httpHandler = new HttpHandler("key", endpoint, RestAdapter.LogLevel.NONE);
+        httpHandler = new HttpHandler(endpoint, RestAdapter.LogLevel.NONE);
     }
 
     @After
@@ -266,7 +266,7 @@ public class RouterTest {
     public void setEndpoint_shouldUpdateBaseRequestUrl() throws Exception {
         startServerAndEnqueue(new MockResponse());
         String endpoint = server.getUrl("/test").toString();
-        HttpHandler httpHandler = new HttpHandler("test", endpoint, RestAdapter.LogLevel.NONE);
+        HttpHandler httpHandler = new HttpHandler(endpoint, RestAdapter.LogLevel.NONE);
         Router router = new ValhallaRouter()
                 .setHttpHandler(httpHandler)
                 .setLocation(new double[] { 40.659241, -73.983776 })

--- a/src/test/java/com/mapzen/valhalla/RouterTest.java
+++ b/src/test/java/com/mapzen/valhalla/RouterTest.java
@@ -1,7 +1,5 @@
 package com.mapzen.valhalla;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 import com.google.gson.Gson;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
@@ -16,12 +14,13 @@ import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-import java.io.File;
 import java.net.MalformedURLException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static com.mapzen.TestUtils.getFixture;
 import static org.fest.assertions.api.Assertions.assertThat;
+import retrofit.RestAdapter;
 
 public class RouterTest {
     @Captor ArgumentCaptor<RouteCallback> callback;
@@ -30,6 +29,7 @@ public class RouterTest {
 
     Router router;
     MockWebServer server;
+    HttpHandler httpHandler;
 
     @Before
     public void setup() throws Exception {
@@ -38,22 +38,13 @@ public class RouterTest {
         MockitoAnnotations.initMocks(this);
         double[] loc = new double[] {1.0, 2.0};
         router = new ValhallaRouter().setLocation(loc).setLocation(loc);
+        String endpoint = server.getUrl("").toString();
+        httpHandler = new HttpHandler("key", endpoint, RestAdapter.LogLevel.NONE);
     }
 
     @After
     public void tearDown() throws Exception {
         server.shutdown();
-    }
-
-    @Test
-    public void shouldHaveDefaultEndpoint() throws Exception {
-        assertThat(router.getEndpoint()).startsWith("https://valhalla.mapzen.com/");
-    }
-
-    @Test
-    public void shouldSetEndpoint() throws Exception {
-        router.setEndpoint("http://testing.com");
-        assertThat(router.getEndpoint()).startsWith("http://testing.com");
     }
 
     @Test
@@ -77,11 +68,6 @@ public class RouterTest {
     public void shouldSetToFoot() throws Exception {
         router.setWalking();
         assertThat(router.getJSONRequest().costing).contains("pedestrian");
-    }
-
-    @Test
-    public void shouldNotSendDntByDefault() {
-        assertThat(router.isDntEnabled()).isFalse();
     }
 
     @Test
@@ -132,10 +118,9 @@ public class RouterTest {
         executorService.execute(new Runnable() {
             @Override
             public void run() {
-                String endpoint = server.getUrl("").toString();
                 RouteCallback callback = Mockito.mock(RouteCallback.class);
                 Router router = new ValhallaRouter()
-                        .setEndpoint(endpoint)
+                        .setHttpHandler(httpHandler)
                         .setLocation(new double[] { 40.659241, -73.983776 })
                         .setLocation(new double[] { 40.671773, -73.981115 });
                 router.setCallback(callback);
@@ -154,9 +139,8 @@ public class RouterTest {
             @Override
             public void run() {
                 RouteCallback callback = Mockito.mock(RouteCallback.class);
-                String endpoint = server.getUrl("").toString();
                 Router router = new ValhallaRouter()
-                        .setEndpoint(endpoint)
+                        .setHttpHandler(httpHandler)
                         .setLocation(new double[]{40.659241, -73.983776})
                         .setLocation(new double[]{40.671773, -73.981115});
                 router.setCallback(callback);
@@ -175,9 +159,8 @@ public class RouterTest {
             @Override
             public void run() {
                 RouteCallback callback = Mockito.mock(RouteCallback.class);
-                String endpoint = server.getUrl("").toString();
                 Router router = new ValhallaRouter()
-                        .setEndpoint(endpoint)
+                        .setHttpHandler(httpHandler)
                         .setLocation(new double[]{40.659241, -73.983776})
                         .setLocation(new double[]{40.671773, -73.981115});
                 router.setCallback(callback);
@@ -196,9 +179,8 @@ public class RouterTest {
             @Override
             public void run() {
                 RouteCallback callback = Mockito.mock(RouteCallback.class);
-                String endpoint = server.getUrl("").toString();
                 Router router = new ValhallaRouter()
-                        .setEndpoint(endpoint)
+                        .setHttpHandler(httpHandler)
                         .setLocation(new double[] { 40.659241, -73.983776 })
                         .setLocation(new double[] { 40.671773, -73.981115 });
                 router.setCallback(callback);
@@ -219,7 +201,7 @@ public class RouterTest {
                 String endpoint = server.getUrl("").toString();
                 RouteCallback callback = Mockito.mock(RouteCallback.class);
                 Router router = new ValhallaRouter()
-                        .setEndpoint(endpoint)
+                        .setHttpHandler(httpHandler)
                         .setLocation(new double[] { 40.659241, -73.983776 })
                         .setLocation(new double[] { 40.671773, -73.981115 });
                 router.setCallback(callback);
@@ -278,41 +260,15 @@ public class RouterTest {
                 .contains("{\"lat\":\"1.0\",\"lon\":\"2.0\",\"heading\":\"180\"}");
     }
 
-    @Test
-    public void setDntEnabled_shouldSendHeader() throws Exception {
-        startServerAndEnqueue(new MockResponse());
-        String endpoint = server.getUrl("").toString();
-        Router router = new ValhallaRouter()
-                .setEndpoint(endpoint)
-                .setLocation(new double[] { 40.659241, -73.983776 })
-                .setLocation(new double[] { 40.671773, -73.981115 })
-                .setDntEnabled(true);
-        ((ValhallaRouter) router).run();
-        RecordedRequest request = server.takeRequest();
-        assertThat(request.getHeader("DNT")).isNotNull();
-        assertThat(request.getHeader("DNT")).isEqualTo("1");
-    }
 
-    @Test
-    public void setDntDisabled_shouldNotSendHeader() throws Exception {
-        startServerAndEnqueue(new MockResponse());
-        String endpoint = server.getUrl("").toString();
-        Router router = new ValhallaRouter()
-                .setEndpoint(endpoint)
-                .setLocation(new double[] { 40.659241, -73.983776 })
-                .setLocation(new double[] { 40.671773, -73.981115 })
-                .setDntEnabled(false);
-        ((ValhallaRouter) router).run();
-        RecordedRequest request = server.takeRequest();
-        assertThat(request.getHeader("DNT")).isNull();
-    }
 
     @Test
     public void setEndpoint_shouldUpdateBaseRequestUrl() throws Exception {
         startServerAndEnqueue(new MockResponse());
         String endpoint = server.getUrl("/test").toString();
+        HttpHandler httpHandler = new HttpHandler("test", endpoint, RestAdapter.LogLevel.NONE);
         Router router = new ValhallaRouter()
-                .setEndpoint(endpoint)
+                .setHttpHandler(httpHandler)
                 .setLocation(new double[] { 40.659241, -73.983776 })
                 .setLocation(new double[] { 40.671773, -73.981115 });
         ((ValhallaRouter) router).run();
@@ -324,15 +280,4 @@ public class RouterTest {
         server.enqueue(response);
     }
 
-    public static String getFixture(String name) {
-        String basedir = System.getProperty("user.dir");
-        File file = new File(basedir + "/src/test/fixtures/" + name + ".route");
-        String fixture = "";
-        try {
-            fixture = Files.toString(file, Charsets.UTF_8);
-        } catch (Exception e) {
-            fixture = "not found";
-        }
-        return fixture;
-    }
 }


### PR DESCRIPTION
- Move setting of api key, endpoint, request log level, and headers into `HttpHandler`
- Remove setting of DNT header from api, can be set in client by creating a subclass of `HttpHandler`
- Add setting of `HttpHandler` to api

Closes #71 #72 