### PR TITLE
Refactor multithreaded tests in RouterTest

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -84,6 +84,7 @@ dependencies {
   testCompile 'com.squareup.okhttp:mockwebserver:2.4.0'
   testCompile 'org.easytesting:fest-reflect:1.4.1'
   testCompile 'com.google.guava:guava:16.0.1'
+  testCompile 'org.json:json:20160212'
 }
 
 apply from: file('../gradle-mvn-push.gradle')

--- a/library/src/test/java/com/mapzen/valhalla/RouterTest.java
+++ b/library/src/test/java/com/mapzen/valhalla/RouterTest.java
@@ -5,7 +5,6 @@ import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
@@ -37,7 +36,7 @@ public class RouterTest {
         double[] loc = new double[] {1.0, 2.0};
         router = new ValhallaRouter().setLocation(loc).setLocation(loc);
         String endpoint = server.getUrl("").toString();
-        httpHandler = new TestHttpHandler(endpoint, RestAdapter.LogLevel.FULL);
+        httpHandler = new TestHttpHandler(endpoint, RestAdapter.LogLevel.NONE);
     }
 
     @After

--- a/library/src/test/java/com/mapzen/valhalla/TestHttpHandler.java
+++ b/library/src/test/java/com/mapzen/valhalla/TestHttpHandler.java
@@ -1,0 +1,37 @@
+package com.mapzen.valhalla;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import retrofit.Callback;
+import retrofit.RestAdapter;
+import retrofit.RetrofitError;
+import retrofit.client.Header;
+import retrofit.client.Response;
+
+public class TestHttpHandler extends HttpHandler {
+
+  TestRoutingService testService;
+
+  public TestHttpHandler(String endpoint, RestAdapter.LogLevel logLevel) {
+    configure(endpoint, logLevel);
+  }
+
+  protected void configure(String endpoint, RestAdapter.LogLevel logLevel) {
+    super.configure(endpoint, logLevel);
+    testService = adapter.create(TestRoutingService.class);
+  }
+
+  @Override
+  public void requestRoute(String routeJson, Callback callback) {
+    try {
+      String route = testService.getRoute(routeJson);
+      List<Header> headers = new ArrayList<>();
+      Response response = new Response("test", 200, "test", headers, null);
+      callback.success(route, response);
+    } catch (RetrofitError error) {
+      callback.failure(error);
+    }
+  }
+
+}

--- a/library/src/test/java/com/mapzen/valhalla/TestRoutingService.java
+++ b/library/src/test/java/com/mapzen/valhalla/TestRoutingService.java
@@ -1,0 +1,13 @@
+package com.mapzen.valhalla;
+
+import retrofit.http.GET;
+import retrofit.http.Query;
+
+/**
+ * Created by sarahlensing on 6/16/16.
+ */
+public interface TestRoutingService {
+  @GET("/route") String getRoute(
+      @Query("json")
+      String json);
+}


### PR DESCRIPTION
- Synchronize http calls using `TestHttpHandler`
- Provide JSON library to tests
- Fix incorrect fixture names

Closes #76 