### PR TITLE
Move gradle default tasks into project root

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,3 +21,5 @@ allprojects {
 task clean(type: Delete) {
   delete rootProject.buildDir
 }
+
+defaultTasks = ['clean', 'assembleDebug', 'copyTask', 'testDebug', 'install']

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,8 +20,6 @@ group = GROUP
 version = VERSION_NAME
 project.archivesBaseName = POM_ARTIFACT_ID
 
-defaultTasks = ['clean', 'assembleDebug', 'copyTask', 'testDebug', 'install']
-
 task copyTask(type: Copy) {
   println "Copying com/mapzen/ontheroad/R.java to android/support/v7/appcompat/R.java"
   from 'build/generated/source/r/debug/com/mapzen/ontheroad'


### PR DESCRIPTION
Currently Circle CI is not running tests for the project. Gradle is only able to find default tasks if they are declared in the root `build.gradle` file, or more specifically the same directory in which the `./gradlew` command is executed.