### PR TITLE
Expose transit stop lat/lon

### DIFF
--- a/library/src/main/java/com/mapzen/valhalla/TransitStop.kt
+++ b/library/src/main/java/com/mapzen/valhalla/TransitStop.kt
@@ -12,6 +12,8 @@ class TransitStop {
     const val KEY_DEPARTURE_DATE_TIME = "departure_date_time"
     const val KEY_IS_PARENT_STOP = "is_parent_stop"
     const val KEY_ASSUMED_SCHEDULE = "assumed_schedule"
+    const val KEY_LON = "lon"
+    const val KEY_LAT = "lat"
   }
 
   lateinit var json: JSONObject
@@ -46,6 +48,14 @@ class TransitStop {
 
   fun getArrivalDateTime(): String {
     return json.optString(KEY_ARRIVAL_DATE_TIME)
+  }
+
+  fun getLon(): Double {
+    return json.optDouble(KEY_LON)
+  }
+
+  fun getLat(): Double {
+    return json.optDouble(KEY_LAT)
   }
 
 }

--- a/library/src/test/fixtures/json_valhalla.transitstop
+++ b/library/src/test/fixtures/json_valhalla.transitstop
@@ -5,7 +5,9 @@
   type: "station",
   arrival_date_time: "2016-06-23T13:40",
   is_parent_stop: true,
-  assumed_schedule: true
+  assumed_schedule: true,
+  lat: "40.741302",
+  lon: "-73.989342"
 }
 
 

--- a/library/src/test/java/com/mapzen/valhalla/TransitStopTest.java
+++ b/library/src/test/java/com/mapzen/valhalla/TransitStopTest.java
@@ -61,4 +61,14 @@ public class TransitStopTest {
     assertThat(transitStop.getAssumedSchedule()).isTrue();
   }
 
+  @Test
+  public void hasLat() {
+    assertThat(transitStop.getLat()).isEqualTo(40.741302);
+  }
+
+  @Test
+  public void hasLon() {
+    assertThat(transitStop.getLon()).isEqualTo(-73.989342);
+  }
+
 }


### PR DESCRIPTION
- We now get two additional properties back in the response (lat/lon). This PR exposes them via `TransitStop` 