### PR TITLE
Ensure transit hex color value is properly formatted

### DIFF
--- a/library/src/main/java/com/mapzen/valhalla/Instruction.kt
+++ b/library/src/main/java/com/mapzen/valhalla/Instruction.kt
@@ -4,7 +4,6 @@ import com.mapzen.helpers.DistanceFormatter
 import com.mapzen.model.ValhallaLocation
 import org.json.JSONException
 import org.json.JSONObject
-import java.util.ArrayList
 import java.util.Locale
 
 open class Instruction {
@@ -252,11 +251,32 @@ open class Instruction {
         return TransitInfo(transitInfoJson)
     }
 
+    /**
+     * Returns a valid hex color value for the transit line or null if no color is available or
+     * the value in the response is invalid.
+     */
     fun getTransitInfoColorHex(): String? {
         if (getTransitInfo() == null) {
             return null
         }
-        val color = getTransitInfo()?.getColor() as Int
-        return "#" + Integer.toString(color, 16)
+
+        val color = getTransitInfo()?.getColor() ?: return null
+        return formatColorString(Integer.toHexString(color))
+    }
+
+    /**
+     * Ensures the color string is a properly formatted 6-digit hexadecimal color value by
+     * prepending leading zeros if necessary. Returns null if the color string is over 6 characters.
+     */
+    private fun formatColorString(color: String): String? {
+        if (color.length > 6) {
+            return null
+        }
+
+        if (color.length == 6) {
+            return "#" + color
+        }
+
+        return formatColorString("0" + color)
     }
 }

--- a/library/src/main/java/com/mapzen/valhalla/TransitInfo.kt
+++ b/library/src/main/java/com/mapzen/valhalla/TransitInfo.kt
@@ -54,8 +54,12 @@ class TransitInfo {
     return json.optString(KEY_SHORT_NAME)
   }
 
-  fun getColor(): Int {
-    return json.getInt(KEY_COLOR)
+  fun getColor(): Int? {
+    if (json.has(KEY_COLOR)) {
+      return json.getInt(KEY_COLOR)
+    } else {
+      return null
+    }
   }
 
   fun getDescription(): String {

--- a/library/src/test/fixtures/transit_color_green.instruction
+++ b/library/src/test/fixtures/transit_color_green.instruction
@@ -1,0 +1,33 @@
+{
+    begin_shape_index: 0,
+    length: 0.161,
+    end_shape_index: 1,
+    instruction: "Go southeast on 19th Street.",
+    street_names: [
+        "19th Street"
+    ],
+    type: 1,
+    time: 0,
+    travel_type: "metro",
+    travel_mode: "transit",
+    transit_info: {
+      transit_stops: [
+        {
+          departure_date_time: "2016-06-23T13:39",
+          name: "23 St",
+          onestop_id: "s-dr5ru3006q-23st<d18s",
+          type: "station"
+        }
+      ],
+      headsign: "CONEY ISLAND - STILLWELL AV",
+      long_name: "Queens Blvd Express/ 6 Av Local",
+      operator_url: "http://web.mta.info/",
+      onestop_id: "r-dr5r-f",
+      short_name: "F",
+      color: 37692,
+      description: "Trains operate at all times between",
+      text_color: 0,
+      operator_onestop_id: "o-dr5r-nyct",
+      operator_name: "MTA"
+    }
+}

--- a/library/src/test/fixtures/transit_color_invalid.instruction
+++ b/library/src/test/fixtures/transit_color_invalid.instruction
@@ -1,0 +1,33 @@
+{
+    begin_shape_index: 0,
+    length: 0.161,
+    end_shape_index: 1,
+    instruction: "Go southeast on 19th Street.",
+    street_names: [
+        "19th Street"
+    ],
+    type: 1,
+    time: 0,
+    travel_type: "metro",
+    travel_mode: "transit",
+    transit_info: {
+      transit_stops: [
+        {
+          departure_date_time: "2016-06-23T13:39",
+          name: "23 St",
+          onestop_id: "s-dr5ru3006q-23st<d18s",
+          type: "station"
+        }
+      ],
+      headsign: "CONEY ISLAND - STILLWELL AV",
+      long_name: "Queens Blvd Express/ 6 Av Local",
+      operator_url: "http://web.mta.info/",
+      onestop_id: "r-dr5r-f",
+      short_name: "F",
+      color: 9223372036854775807,
+      description: "Trains operate at all times between",
+      text_color: 0,
+      operator_onestop_id: "o-dr5r-nyct",
+      operator_name: "MTA"
+    }
+}

--- a/library/src/test/fixtures/transit_no_color.instruction
+++ b/library/src/test/fixtures/transit_no_color.instruction
@@ -1,0 +1,32 @@
+{
+    begin_shape_index: 0,
+    length: 0.161,
+    end_shape_index: 1,
+    instruction: "Go southeast on 19th Street.",
+    street_names: [
+        "19th Street"
+    ],
+    type: 1,
+    time: 0,
+    travel_type: "metro",
+    travel_mode: "transit",
+    transit_info: {
+      transit_stops: [
+        {
+          departure_date_time: "2016-06-23T13:39",
+          name: "23 St",
+          onestop_id: "s-dr5ru3006q-23st<d18s",
+          type: "station"
+        }
+      ],
+      headsign: "CONEY ISLAND - STILLWELL AV",
+      long_name: "Queens Blvd Express/ 6 Av Local",
+      operator_url: "http://web.mta.info/",
+      onestop_id: "r-dr5r-f",
+      short_name: "F",
+      description: "Trains operate at all times between",
+      text_color: 0,
+      operator_onestop_id: "o-dr5r-nyct",
+      operator_name: "MTA"
+    }
+}

--- a/library/src/test/java/com/mapzen/valhalla/InstructionTest.java
+++ b/library/src/test/java/com/mapzen/valhalla/InstructionTest.java
@@ -142,12 +142,32 @@ public class InstructionTest {
     }
 
     @Test
+    public void getTransitInfoColorHex_shouldReturnSixDigitHexValue() throws Exception {
+        final JSONObject json = new JSONObject(getInstructionFixture("transit_color_green"));
+        instruction = new Instruction(json);
+        assertThat(instruction.getTransitInfoColorHex()).isEqualTo("#00933c");
+    }
+
+    @Test
+    public void getTransitInfoColorHex_shouldReturnNullIfNoneAvailable() throws Exception {
+        final JSONObject json = new JSONObject(getInstructionFixture("transit_no_color"));
+        instruction = new Instruction(json);
+        assertThat(instruction.getTransitInfoColorHex()).isNull();
+    }
+
+    @Test
+    public void getTransitInfoColorHex_shouldReturnNullIfColorIsInvalid() throws Exception {
+        final JSONObject json = new JSONObject(getInstructionFixture("transit_color_invalid"));
+        instruction = new Instruction(json);
+        assertThat(instruction.getTransitInfoColorHex()).isNull();
+    }
+
+    @Test
     public void hasCorrectDirection() throws Exception {
         Route myRoute = getRoute("brooklyn_valhalla");
         instruction = myRoute.getCurrentInstruction();
         assertThat(instruction.getDirection()).isEqualTo("W");
     }
-
 
     @Test
     public void hasBeginPolygonIndex() throws Exception {


### PR DESCRIPTION
* Adds leading zeros to hex color value if less than 6 characters
* Checks for missing and invalid (over 6 character) hex color values

Fixes #86